### PR TITLE
Ensure scripts run from project root with PYTHONPATH

### DIFF
--- a/scripts/start-web.sh
+++ b/scripts/start-web.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+cd "$(dirname "$0")/.."
+export PYTHONPATH="$(pwd):${PYTHONPATH}"
+
 # Run migrations with retry until database is ready
 until alembic upgrade head; do
   echo "Database not ready, retrying in 1s..."

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+cd "$(dirname "$0")/.."
+export PYTHONPATH="$(pwd):${PYTHONPATH}"
+
 # Run migrations with retry until database is ready
 until alembic upgrade head; do
   echo "Database not ready, retrying in 1s..."


### PR DESCRIPTION
## Summary
- Guarantee web and worker scripts run migrations from project root
- Export project root to PYTHONPATH for both scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa68345bc832f9fdc166870ad8605