### PR TITLE
Fix Alembic env module path for settings import

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,6 +5,8 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from config import settings
 from web.models import Base
 


### PR DESCRIPTION
## Summary
- ensure Alembic env.py can import project settings by adding repository root to `sys.path`

## Testing
- `alembic upgrade head` *(fails: Compiler can't render element of type ARRAY)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaa726eccc832f9fb507243fe17368