### PR TITLE
Handle non-DB migration errors in start scripts

### DIFF
--- a/scripts/start-web.sh
+++ b/scripts/start-web.sh
@@ -4,10 +4,20 @@ set -e
 cd "$(dirname "$0")/.."
 export PYTHONPATH="$(pwd):${PYTHONPATH}"
 
-# Run migrations with retry until database is ready
-until alembic upgrade head; do
-  echo "Database not ready, retrying in 1s..."
-  sleep 1
+# Run migrations with retry only for connection errors
+while true; do
+  if output=$(alembic upgrade head 2>&1); then
+    break
+  fi
+
+  echo "$output"
+  if echo "$output" | grep -qE '(Connection refused|could not connect|network is unreachable|Database .+ does not exist)'; then
+    echo "Database not ready, retrying in 1s..."
+    sleep 1
+  else
+    echo "Migration failed" >&2
+    exit 1
+  fi
 done
 
 # Start web server

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -4,10 +4,20 @@ set -e
 cd "$(dirname "$0")/.."
 export PYTHONPATH="$(pwd):${PYTHONPATH}"
 
-# Run migrations with retry until database is ready
-until alembic upgrade head; do
-  echo "Database not ready, retrying in 1s..."
-  sleep 1
+# Run migrations with retry only for connection errors
+while true; do
+  if output=$(alembic upgrade head 2>&1); then
+    break
+  fi
+
+  echo "$output"
+  if echo "$output" | grep -qE '(Connection refused|could not connect|network is unreachable|Database .+ does not exist)'; then
+    echo "Database not ready, retrying in 1s..."
+    sleep 1
+  else
+    echo "Migration failed" >&2
+    exit 1
+  fi
 done
 
 # Start worker process and keep logs streaming


### PR DESCRIPTION
## Summary
- retry alembic migrations only on connection-related errors
- exit with a failure for other migration errors

## Testing
- `pytest -q >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68aaaaf012dc832fbec4e6d7c7d9a1c8